### PR TITLE
Change addon summary to something smaller

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -9,7 +9,7 @@
     </extension>
     <extension point="xbmc.addon.metadata">
         <platform>all</platform>
-        <summary><![CDATA[kmediatorrent: Torrent streaming 
+        <summary><![CDATA[Torrent streaming 
         for KODI/XBMC.]]></summary>
         <description><![CDATA[Watch torrents directly from KODI/XBMC, without waiting.]]></description>
     </extension>


### PR DESCRIPTION
Dear jmarth,

The skin I'm using is aeon nox and the font size is huge. Kmediatorrent brings issues due to the fact of having so many text on the addon summary. It basically overlays the text on top of other addons on the list. Please consider to rename the addon summary to something smaller to improve compatibility with other skins.

Thanks

PS: My change is just an example