### PR TITLE
Avoid zombie processes

### DIFF
--- a/resources/site-packages/kmediatorrent/torrent2http.py
+++ b/resources/site-packages/kmediatorrent/torrent2http.py
@@ -124,6 +124,7 @@ def start(**kwargs):
             plugin.log.info("Trying to stop torrent2http at http://%s/shutdown" % proc.bind_address)
             try:
                 url_get("http://%s/shutdown" % proc.bind_address, with_immunicity=False)
+                proc.wait()
             except Exception, e:
                 plugin.log.info('Failed to sto torrent2http')
                 map(plugin.log.info, traceback.format_exc(e).split('\n'))

--- a/resources/site-packages/koditorrent/torrent2http.py
+++ b/resources/site-packages/koditorrent/torrent2http.py
@@ -104,6 +104,7 @@ def start(**kwargs):
             plugin.log.info("Trying to stop torrent2http at http://%s/shutdown" % proc.bind_address)
             try:
                 url_get("http://%s/shutdown" % proc.bind_address, with_immunicity=False)
+                proc.wait()
             except Exception, e:
                 plugin.log.info('Failed to sto torrent2http')
                 map(plugin.log.info, traceback.format_exc(e).split('\n'))


### PR DESCRIPTION
While using KMediaTorrent (in Linux) all killed process remains in zombie state because return value is not checked (no pool(), wait() or communicate() is done after kill the process)